### PR TITLE
bump version of HdrHistogram to fix ArrayIndexOutOfBoundsException

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>org.hdrhistogram</groupId>
 			<artifactId>HdrHistogram</artifactId>
-			<version>2.1.10</version>
+			<version>2.1.12</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bumping Version 2.1.12 includes fix for HdrHistogram/HdrHistogram#156

This should solve the exception we are seeing:
java.util.concurrent.CompletionException: java.lang.ArrayIndexOutOfBoundsException: value outside of histogram covered range. Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 1332405 out of bounds for length 1310720

Signed-off-by: Vanessa Busch <vbusch@redhat.com>