### PR TITLE
Replace period with underscore in histogram env var

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/HistogramFactory.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/HistogramFactory.java
@@ -28,7 +28,7 @@ public class HistogramFactory {
     private static int NUMBER_OF_SIGNIFICANT_VALUE_DIGITS = DEFAULT_NUMBER_OF_SIGNIFICANT_VALUE_DIGITS;
 
     static {
-        String value = System.getenv("HISTOGRAM.NUMBER_OF_SIGNIFICANT_VALUE_DIGITS");
+        String value = System.getenv("HISTOGRAM_NUMBER_OF_SIGNIFICANT_VALUE_DIGITS");
         if (value != null && !value.isEmpty()) {
             try {
                 NUMBER_OF_SIGNIFICANT_VALUE_DIGITS = Integer.parseInt(value);


### PR DESCRIPTION
It seems that `.` is not a valid character in an environment variable name:

```
$ export HISTOGRAM.NUMBER_OF_SIGNIFICANT_VALUE_DIGITS=0
-bash: export: `HISTOGRAM.NUMBER_OF_SIGNIFICANT_VALUE_DIGITS=0': not a valid identifier
$ HISTOGRAM.NUMBER_OF_SIGNIFICANT_VALUE_DIGITS=0
-bash: HISTOGRAM.NUMBER_OF_SIGNIFICANT_VALUE_DIGITS=0: command not found
```

This is related to #2.